### PR TITLE
Make it possible to target JS output.

### DIFF
--- a/data/default.nix
+++ b/data/default.nix
@@ -12,6 +12,7 @@ let
     , srcdir ? "./src"
     , targets ? []
     , versionsDat ? ./versions.dat
+    , outputJavaScript ? false
     }:
     stdenv.mkDerivation {
       inherit name src;
@@ -25,11 +26,12 @@ let
 
       installPhase = let
         elmfile = module: "\${srcdir}/\${builtins.replaceStrings ["."] ["/"] module}.elm";
+        extension = if outputJavaScript then "js" else "html";
       in ''
         mkdir -p \$out/share/doc
         \${lib.concatStrings (map (module: ''
           echo "compiling \${elmfile module}"
-          elm make \${elmfile module} --output \$out/\${module}.html --docs \$out/share/doc/\${module}.json
+          elm make \${elmfile module} --output \$out/\${module}.\${extension} --docs \$out/share/doc/\${module}.json
         '') targets)}
       '';
     };
@@ -39,4 +41,5 @@ in mkDerivation {
   src = ./.;
   targets = ["Main"];
   srcdir = "${srcdir}";
+  outputJavaScript = false;
 }


### PR DESCRIPTION
Introduce optional `outputJavaScript` in default.nix. This change is non breaking. If this gets accepted I would like to also add optimisation for js files via uglify-js [as suggested in official documentation](https://guide.elm-lang.org/optimization/asset_size.html) in next PR.