### PR TITLE
Implement minification of js output

### DIFF
--- a/data/default.nix
+++ b/data/default.nix
@@ -17,7 +17,8 @@ let
     stdenv.mkDerivation {
       inherit name src;
 
-      buildInputs = [ elmPackages.elm ];
+      buildInputs = [ elmPackages.elm ]
+        ++ lib.optional outputJavaScript nodePackages_10_x.uglify-js;
 
       buildPhase = pkgs.elmPackages.fetchElmDeps {
         elmPackages = import srcs;
@@ -32,6 +33,11 @@ let
         \${lib.concatStrings (map (module: ''
           echo "compiling \${elmfile module}"
           elm make \${elmfile module} --output \$out/\${module}.\${extension} --docs \$out/share/doc/\${module}.json
+          \${lib.optionalString outputJavaScript ''
+            echo "minifying \${elmfile module}"
+            uglifyjs $out/\${module}.\${extension} --compress 'pure_funcs="F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9",pure_getters,keep_fargs=false,unsafe_comps,unsafe' \\
+                | uglifyjs --mangle --output=$out/\${module}.min.\${extension}
+          ''}
         '') targets)}
       '';
     };


### PR DESCRIPTION
This implements minification of js files using uglify-js.
See [official documentation](https://guide.elm-lang.org/optimization/asset_size.html)

tested on todo-mvc example:

```
❯❯❯ ll $(readlink result)
total 172K
dr-xr-xr-x 3 root root 4.0K Jan  1  1970 share
-r--r--r-- 1 root root 128K Jan  1  1970 Main.js
-r--r--r-- 1 root root  39K Jan  1  1970 Main.min.js
```

and with gzip:

```
❯❯❯ cat result/Main.js | gzip -c | wc -c
29247
❯❯❯ cat result/Main.min.js | gzip -c | wc -c
13862
```
